### PR TITLE
Create path to request correctly

### DIFF
--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -47,6 +47,7 @@ class ClientHandler {
 		int	retrieveResponse(void);
 		void validateHttpHeaders(void);
 		std::string findDirectory(std::string uri);
+		std::string createPath(struct Route route, std::string uri);
 		void createErrorResponseAndCleanUp(int code, std::string body, std::string message);
 	private:
 	std::string raw_data;
@@ -59,4 +60,5 @@ class ClientHandler {
 	double timeoutTime;
 };
 
+std::ostream &operator<<(std::ostream &output, ClientHandler const &obj);
 #endif

--- a/HttpException.cpp
+++ b/HttpException.cpp
@@ -36,7 +36,7 @@ std::string HttpException::extractFile(void)
 
 	if (!inputFile)
 	{
-		std::cout << this->file << std::endl;
+		// std::cout << this->file << std::endl;
 		std::cerr << "Error opening file httpexception" << std::endl;
 		return "";
 	}

--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -13,7 +13,6 @@ HttpRequest::HttpRequest(HttpRequest const &other)
 	this->requestLine = other.requestLine;
 	this->query = other.query;
 	this->headers = other.headers;
-	// this->sectionsVec = other.sectionsVec;
 	this->sectionInfo = other.sectionInfo;
 }
 // Setters and getters
@@ -374,4 +373,46 @@ void	HttpRequest::cleanProperties(void)
 	sectionInfo.body.clear();
 	sectionInfo.indexBinary = 0;
 	sectionInfo.myMap.clear();
+}
+
+std::ostream &operator<<(std::ostream &output, HttpRequest const &request) {
+    // Print the request line
+    std::map<std::string, std::string> requestLine = request.getHttpRequestLine();
+    output << "HTTP Request Line:" << std::endl;
+    for (std::map<std::string, std::string>::const_iterator it = requestLine.begin(); it != requestLine.end(); ++it) {
+        output << it->first << ": " << it->second << std::endl;
+    }
+
+    // Print the URI
+    output << "URI: " << request.getUri() << std::endl;
+
+    // Print the method
+    output << "Method: " << request.getMethod() << std::endl;
+
+    // Print the query
+    output << "Query: " << request.getQuery() << std::endl;
+
+    // Print the body content
+    output << "Body Content: " << request.getBodyContent() << std::endl;
+
+    // Print the content type
+    output << "Content Type: " << request.getContentType() << std::endl;
+
+    // Print the content length
+    output << "Content Length: " << request.getContentLength() << std::endl;
+
+    // Print the host
+    output << "Host: " << request.getHost() << std::endl;
+
+    // Print the protocol
+    output << "Protocol: " << request.getProtocol() << std::endl;
+
+    // Print the headers
+    output << "Headers:" << std::endl;
+    std::map<std::string, std::string> headers = request.getHttpHeaders();
+    for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
+        output << it->first << ": " << it->second << std::endl;
+    }
+
+    return output;
 }

--- a/HttpRequest.hpp
+++ b/HttpRequest.hpp
@@ -67,4 +67,6 @@ class HttpRequest {
 		struct section						sectionInfo;
 };
 
+std::ostream &operator<<(std::ostream &output, HttpRequest const &request);
+
 #endif

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -292,11 +292,6 @@ void Webserver::createNewClient(int fd)
 	clientPoll.events = POLLIN;
 	this->poll_sets.push_back(clientPoll);
 	std::vector<pollfd> newSet = poll_sets;
-	std::cout << "size: " << newSet.size() << std::endl;
-	for (int i = 0; i < newSet.size(); i++)
-	{
-		Logger::debug(Utils::toString(newSet[i].fd));
-	}
 	InfoServer *server = matchFD(fd);
 	//printServInfo(server);
 	ClientHandler newClient(clientFd, *server);

--- a/default.conf
+++ b/default.conf
@@ -25,7 +25,7 @@ server {
 	}
 
 	location /upload {
-		allow					POST DELETE HEAD;
+		allow					POST DELETE GET HEAD;
 		root					/www;
 		limit_client_body_size	10M;
 		content_type			text/html text/plain image/jpeg image/png;
@@ -101,3 +101,108 @@ server {
 		internal;
 	}
 }
+
+server {
+	port					8081;
+	server_name				localhost;
+	root					/www;
+	client_max_body_size	5M;
+	keepalive_timeout		75;
+	client_body_timeout		12;
+	client_header_timeout	12;
+	cgi_path				./cgi_bin;
+	cgi_extension			.py;
+
+	# specifies how the server should respond to requests for the root path (no path specified)
+	location / {
+		allow			GET;
+		root			/www/static;
+		index			index.html;
+		content_type	text/html;
+	}
+
+	location /static {
+		allow					POST GET DELETE;
+		root					/www;
+		limit_client_body_size	10M;
+		content_type			text/html text/plain;
+	}
+
+	location /upload {
+		allow					POST DELETE GET HEAD;
+		root					/www;
+		limit_client_body_size	10M;
+		content_type			text/html text/plain image/jpeg image/png;
+	}
+
+	location /favicon.ico {
+		allow					GET POST;
+		root					/www/static;
+	}
+
+	location /ciao {
+		allow					GET POST;
+		root					/www/static;
+	}
+
+	#This needs to be checked, need to be done
+	location /old-page {
+		root					/www;
+		redirect				/static;
+	}
+
+	# location /delete {
+	#     allow DELETE;
+	#     root /www/uploads;
+	# }
+
+	# CGI scripts (for dynamic content)
+	location /cgi-bin/ {
+		allow			POST;
+		root			/www/cgi-bin;
+		fastcgi_pass	backend;
+		cgi_path		./cgi_bin/upload.py;
+	}
+
+	# Route to serve the error files (these files should exist at the specified locations)
+	location /400.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /403.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /404.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /405.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /409.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /413.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /415.html {
+		root	/www/errors;
+		internal;
+	}
+
+	location /505.html {
+		root	/www/errors;
+		internal;
+	}
+}
+

--- a/main.cpp
+++ b/main.cpp
@@ -113,3 +113,60 @@ int main(void)
 		Logger::error("Parsing configuration file");
 	return (0);
 }
+
+// void printServInfo(InfoServer *server)
+// {
+// 	std::map<std::string, std::string>::iterator	mapIt;
+// 	std::map<std::string, Route>::iterator			locMetIt;
+// 	std::set<std::string>::iterator					setIt;
+// 	std::map<std::string, std::string>::iterator	varIt;
+// 	std::cout << "Checking server " << std::endl;
+// 	std::cout << "Checking harcoded variables" << std::endl << std::endl;
+// 	if (server->getIP() != "")
+// 		std::cout << "IP is " << server->getIP() <<std::endl;
+// 	else
+// 		std::cout << "IP doesn't exist!" << std::endl;
+// 	if (server->getIndex() != "")
+// 		std::cout << "Index is " << server->getIndex() <<std::endl;
+// 	else
+// 		std::cout << "Index doesn't exist!" << std::endl;
+// 	if (server->getRoot() != "")
+// 		std::cout << "Root is " << server->getRoot() <<std::endl;
+// 	else
+// 		std::cout << "Root doesn't exist!" << std::endl;
+// 	if (server->getPort() != "")
+// 		std::cout << "Port is " << server->getPort() <<std::endl;
+// 	else
+// 		std::cout << "Port doesn't exist!" << std::endl;
+
+// 	std::cout << std::endl << "Checking all the settings" << std::endl << std::endl;
+
+// 	std::map<std::string, std::string> map;
+
+// 	map = server->getSetting();
+// 	for(mapIt = map.begin(); mapIt != map.end(); mapIt++)
+// 		std::cout << mapIt->first << " = " << mapIt->second << std::endl;
+
+// 	std::cout << std::endl << "Checking all locations" << std::endl << std::endl;
+
+// 	std::map<std::string, Route> routes;
+
+// 	routes = server->getRoute();
+// 	for(locMetIt = routes.begin(); locMetIt != routes.end(); locMetIt++)
+// 	{
+// 		std::cout << "Checking location " << locMetIt->first << std::endl << std::endl;
+// 		std::cout << "URI: " << locMetIt->second.uri << std::endl;
+// 		std::cout << "Path: " << locMetIt->second.path << std::endl;
+// 		if (locMetIt->second.internal)
+// 			std::cout << "It is internal!" << std::endl;
+// 		else
+// 			std::cout << "It is not internal!" << std::endl;
+// 		std::cout << "Allowed methods: ";
+// 		for(setIt = locMetIt->second.methods.begin(); setIt != locMetIt->second.methods.end(); setIt++)
+// 			std::cout << (*setIt) << " ";
+// 		std::cout << std::endl << "Other variables:" << std::endl;
+// 		for(varIt = locMetIt->second.locSettings.begin(); varIt != locMetIt->second.locSettings.end(); varIt++)
+// 			std::cout << varIt->first << " = " << varIt->second << std::endl;
+// 		std::cout << std::endl;
+// 	}
+// }


### PR DESCRIPTION
After parsing the http request, we now look the correct route and create route path based on uri: if it is a folder, we just append the uri to the path of the route, if it is a file, we then append only the file to the route's path. It works for all methods (get both retrieve and download, post and delete). It also work if someone will ask for a page + index.html

Note: still undecided how the route path should be created while parsing the configuration file. 