### PR TITLE
New HttpException class init

### DIFF
--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -9,6 +9,8 @@ ClientHandler::ClientHandler(int fd, InfoServer const &configInfo)
 	this->configInfo = configInfo;
 	this->startingTime = time(NULL);
 	this->timeoutTime = atof(this->configInfo.getSetting()["keepalive_timeout"].c_str());
+	std::string errorPath = this->configInfo.getSetting()["error_path"];
+	HttpException::setHtmlRootPath(errorPath);
 }
 
 //Setters and Getters
@@ -173,7 +175,6 @@ int ClientHandler::manageRequest(void)
 				locationPath = findDirectory(uri);
 				struct Route newRoute;
 				newRoute = this->configInfo.getRoute()[locationPath];
-				printRoute(newRoute);
 				route = newRoute;
 				std::string newPath;
 				newPath = createPath(route, uri);

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -23,8 +23,6 @@ Webserver::Webserver(Config& file)
 		if (this->configInfo[i]->getFD() > 0)
 			addServerSocketsToPoll(this->configInfo[i]->getFD());
 	}
-	std::string errorPagePath = "/www/errors"; //need to take care of this
-	HttpException::setHtmlRootPath(errorPagePath);
 }
 
 Webserver::~Webserver()


### PR DESCRIPTION
Since each server could have different errors path, I moved from the WebServer constructor to ClientHandler constructor, so each client is set to have correct path