### PR TITLE
Uppercase method and protocol

### DIFF
--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -145,6 +145,7 @@ void HttpRequest::parseRequestLine(std::string str)
 	if (index != std::string::npos)
 	{
 		method = str.substr(0, index);
+		std::transform(method.begin(), method.end(), method.begin(), Utils::toUpperCase);
 		this->requestLine["method"] = method;
 	}
 	else
@@ -169,6 +170,7 @@ void HttpRequest::parseRequestLine(std::string str)
 	if (index != std::string::npos)
 	{
 		protocol = str.substr(0, index);
+		std::transform(method.begin(), method.end(), method.begin(), Utils::toUpperCase);
 		requestLine["protocol"] = protocol;
 	}
 	else

--- a/Utils.hpp
+++ b/Utils.hpp
@@ -59,6 +59,11 @@ class Utils {
 		{
 			return std::tolower(static_cast<unsigned char>(c));
 		}
+
+		static char toUpperCase(char c)
+		{
+			return std::toupper(static_cast<unsigned char>(c));
+		}
 	private:
 		Utils();		
 };


### PR DESCRIPTION
The initial plan was to make all lowercase, but I then realise that we need to check the allowed methods in the location block, and they are uppercase. the protocol cause I don't know, to be consistent in the first line