### PR TITLE
set content type for response only if method is post

### DIFF
--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -427,6 +427,8 @@ std::string ClientHandler::prepareResponse(struct Route route)
 	else
 		throw MethodNotAllowedException();
 	HttpResponse http(code, body);
+	if (method == "POST")
+		http.setContentType(this->request.getContentType());
 	response = http.composeRespone();
 	return response;
 }

--- a/HttpResponse.cpp
+++ b/HttpResponse.cpp
@@ -47,6 +47,10 @@ void HttpResponse::setUriLocation(std::string url)
 	this->redirectedUrl = url;
 }
 
+void HttpResponse::setContentType(std::string type)
+{
+	this->type = type;
+}
 // Main functions
 std::string HttpResponse::composeRespone(void)
 {
@@ -81,10 +85,7 @@ std::string HttpResponse::generateHttpHeaders(void)
 	std::string	timeStamp;
 
 	if (!(this->body.empty()))
-	{
-		type = verifyType(this->body);
-		headers += "Content-Type: " + type + "\r\n";
-	}
+		headers += "Content-Type: " + this->type + "\r\n";
 	if (this->statusCode == 301)
 		headers += "Location: " + this->redirectedUrl + "\r\n"; //need to take care
 	length = Utils::toString(this->body.size());
@@ -94,13 +95,6 @@ std::string HttpResponse::generateHttpHeaders(void)
 	headers += "Cache-Control: no-cache\r\n";
 	headers += "Connection: keep-alive\r\n";
 	return headers;
-}
-
-std::string HttpResponse::verifyType(std::string str) //need to take care
-{
-	if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
-		return "text/html";
-	return "image/jpeg";
 }
 
 std::string HttpResponse::findTimeStamp(void)

--- a/HttpResponse.hpp
+++ b/HttpResponse.hpp
@@ -23,6 +23,7 @@ class HttpResponse {
 		HttpResponse(int code, std::string body);
 
 		void 		setUriLocation(std::string url);
+		void		setContentType(std::string type);
 		std::string composeRespone();
 		std::string generateStatusLine(int);
 		std::string generateHttpHeaders();
@@ -34,6 +35,7 @@ class HttpResponse {
 		std::string body;
 		std::string redirectedUrl;
 		std::map<int, std::string> mapStatusCode;
+		std::string type;
 		
 };
 

--- a/ServerSockets.cpp
+++ b/ServerSockets.cpp
@@ -42,7 +42,7 @@ void	ServerSockets::initSockets(void)
 		Logger::error("Failed to create socket on port " + port + ": " + std::string(strerror(errno)));
 		return;
 	}
-	Logger::info("Socker on port " + port + ": successfully created");
+	Logger::info("Socket on " + ip + " on port " + port + ": successfully created");
 }
 
 int ServerSockets::createSocket(void)

--- a/issues.txt
+++ b/issues.txt
@@ -1,20 +1,5 @@
-1) correctly set up http header location for redirection
-	=> if (this->statusCode == 301)
-			headers += "Location: http://localhost:8080/\r\n";
-
-2) implement logic to extract correct content type
-	=> std::string HttpResponse::verifyType(std::string str)
-		{
-			if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
-				return "text/html";
-			return "image/jpeg";
-		}
-
-3) get info from config file, take in mind each server has different error path(?)
-	=> std::string errorPagePath = "/www/errors";
 4) maybe it is fine
 	=> body = extractContent(page.path + "success_upload" + "/" + page.locSettings.find("index")->second);
 5) it any other upload comes in, throw not supported/implemented
 	=> if (contentType.find("boundary") != std::string::npos)
-6) make sure also the requestline is in lowercase for consistency
 7) create tests


### PR DESCRIPTION
We set the content type for the http header response by calling setter from httpResponse, so it takes the content type from the request (no need to check for extensions). Just checking if it is POST request. maybe it can be done more nicely, but it works 