### PR TITLE
Not implemented for post requests

### DIFF
--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -51,17 +51,12 @@ void ClientHandler::validateHttpHeaders(struct Route route)
 		if (it->first == "content-type")
 		{
 			std::string type;
-			if (it->second.find(";") != std::string::npos)
+			if (it->second.find("multipart/form-data") != std::string::npos)
 			{
 				std::string genericType = it->second.substr(0, it->second.find(";"));
-				if (genericType == "multipart/form-data")
-				{
-					type = this->request.getHttpSection().myMap["content-type"];
-					if (type.length() >= 1)
-						type.erase(type.length() - 1);
-				}
-				else
-					throw UnsupportedMediaTypeException();
+				type = this->request.getHttpSection().myMap["content-type"];
+				if (type.length() >= 1)
+					type.erase(type.length() - 1);
 			}
 			else
 				type = it->second;
@@ -372,6 +367,34 @@ std::string ClientHandler::uploadFile(std::string path)
 	if (checkNameFile(fileName, path) == 1)
 		throw ConflictException();
 	path += "/" + fileName;
+	std::string contentType = this->request.getHttpHeaders()["content-type"];
+	if (contentType == "text/plain")
+	{
+		std::string filename = "text_plain.txt";
+
+		// Create an ofstream object to open the file in append mode
+		std::ofstream outfile;
+	
+		// Open the file in append mode
+		outfile.open(filename.c_str(), std::ios::app); // std::ios::app opens the file for appending
+	
+		// Check if the file is open
+		if (!outfile.is_open()) {
+			std::cerr << "Error opening file for writing." << std::endl;
+			return ""; // Return with an error code
+		}
+	
+		// Data to append
+		std::string dataToAppend = this->request.getBodyContent();
+	
+		// Write data to the file
+		outfile << dataToAppend;
+	
+		// Close the file
+		outfile.close();
+	
+		std::cout << "Data appended to " << filename << " successfully." << std::endl;
+	}
 	int file = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 	if (file < 0)
 		throw BadRequestException();

--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -67,7 +67,7 @@ std::string HttpRequest::getContentType(void) const
 
 std::string HttpRequest::getContentLength(void) const
 {
-	return findValue(this->headers, "content-length");
+	return Utils::toString(this->sectionInfo.body.length());
 }
 
 std::string HttpRequest::getHost(void) const
@@ -253,7 +253,11 @@ struct section HttpRequest::extractSections(std::string buffer, int firstB, int 
 				key = line.substr(0, index);
 				if (line[line.find(":") + 1] != ' ')
 					throw BadRequestException();
-				value = line.substr(index + 2);
+				size_t indexEnd = line.find("\r");
+				if (indexEnd != std::string::npos)
+					value = line.substr(index + 2, indexEnd - index - 2);
+				else
+					throw BadRequestException();
 			}
 			else
 				throw BadRequestException();
@@ -391,7 +395,7 @@ std::ostream &operator<<(std::ostream &output, HttpRequest const &request) {
     output << "Body Content: " << request.getBodyContent() << std::endl;
 
     // Print the content type
-    output << "Content Type: " << request.getContentType() << std::endl;
+    output << "Content Type: " << request.getContentType() << ";" << std::endl;
 
     // Print the content length
     output << "Content Length: " << request.getContentLength() << std::endl;
@@ -406,7 +410,7 @@ std::ostream &operator<<(std::ostream &output, HttpRequest const &request) {
     output << "Headers:" << std::endl;
     std::map<std::string, std::string> headers = request.getHttpHeaders();
     for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
-        output << it->first << ": " << it->second << std::endl;
+        output << it->first << ": " << it->second << ";" << std::endl;
     }
 
     return output;

--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -111,10 +111,11 @@ void HttpRequest::parseBody(std::string method, std::string buffer, int size)
 	std::map<std::string, std::string>::iterator it;
 
 	if (method == "POST")
-	{
+	{	
+		Logger::debug(contentType);
 		if (contentType.find("multipart/form-data") != std::string::npos)
 			parseMultiPartBody(buffer, size);
-		else if (contentType.find("text/plain"))
+		else if (contentType.find("text/plain\r"))
 		{
 			struct section data;
 			data.indexBinary = 0;
@@ -198,7 +199,11 @@ void HttpRequest::parseHeaders(std::istringstream& str)
 			key = line.substr(0, index);
 			if (line[line.find(":") + 1] != ' ')
 				throw BadRequestException();
-			value = line.substr(index + 2);
+			size_t indexEnd = line.find("\r");
+			if (indexEnd != std::string::npos)
+				value = line.substr(index + 2, indexEnd - index - 2);
+			else
+				throw BadRequestException();
 		}
 		else
 			throw BadRequestException();

--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -112,21 +112,8 @@ void HttpRequest::parseBody(std::string method, std::string buffer, int size)
 
 	if (method == "POST")
 	{	
-		Logger::debug(contentType);
 		if (contentType.find("multipart/form-data") != std::string::npos)
 			parseMultiPartBody(buffer, size);
-		else if (contentType.find("text/plain\r"))
-		{
-			struct section data;
-			data.indexBinary = 0;
-			std::string::size_type bodyStart = buffer.find("\r\n\r\n");
-			if (bodyStart != std::string::npos)
-			{
-				bodyStart += 4;
-				data.body = buffer.substr(bodyStart, buffer.length() - bodyStart - 2);
-			}
-			this->sectionInfo = data;
-		}
 		else
 			throw NotImplementedException();
 	}

--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -112,9 +112,9 @@ void HttpRequest::parseBody(std::string method, std::string buffer, int size)
 
 	if (method == "POST")
 	{
-		if (contentType.find("boundary") != std::string::npos) //need to take care
+		if (contentType.find("multipart/form-data") != std::string::npos)
 			parseMultiPartBody(buffer, size);
-		else
+		else if (contentType.find("text/plain"))
 		{
 			struct section data;
 			data.indexBinary = 0;
@@ -126,6 +126,8 @@ void HttpRequest::parseBody(std::string method, std::string buffer, int size)
 			}
 			this->sectionInfo = data;
 		}
+		else
+			throw NotImplementedException();
 	}
 	else
 		throw BadRequestException();

--- a/issues.txt
+++ b/issues.txt
@@ -1,20 +1,7 @@
-1) correctly set up http header location for redirection
-	=> if (this->statusCode == 301)
-			headers += "Location: http://localhost:8080/\r\n";
 
-2) implement logic to extract correct content type
-	=> std::string HttpResponse::verifyType(std::string str)
-		{
-			if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
-				return "text/html";
-			return "image/jpeg";
-		}
 
-3) get info from config file, take in mind each server has different error path(?)
-	=> std::string errorPagePath = "/www/errors";
-4) maybe it is fine
-	=> body = extractContent(page.path + "success_upload" + "/" + page.locSettings.find("index")->second);
+
 5) it any other upload comes in, throw not supported/implemented
 	=> if (contentType.find("boundary") != std::string::npos)
-6) make sure also the requestline is in lowercase for consistency
+6)make sure there are not \r\n trailing
 7) create tests


### PR DESCRIPTION
Decided, for now, to handle only multipart/form-data, and give 501 not implemented if other types of upload are requested.
Also, made sure there are no \r after each value header during the parsing
Fix the content length: I was returning the total length of the request and not the length of the content body
tested with siege and two servers