### PR TITLE
Retrieve file web browser

### DIFF
--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -275,7 +275,7 @@ std::string ClientHandler::extractContent(std::string path)
 	std::string buffer;
 	buffer.resize(size);
 	if (!(inputFile.read(&buffer[0], size)))
-		throw ServiceUnavailabledException();
+		throw NotFoundException();
 	inputFile.close();
 	return buffer;
 }
@@ -341,7 +341,7 @@ int checkNameFile(std::string str, std::string path)
 	folder = opendir(path.c_str());
 	std::string convStr;
 	if (folder == NULL)
-		throw ServiceUnavailabledException();
+		throw NotFoundException();
 	while ((data = readdir(folder)))
 	{
 		convStr = data->d_name;
@@ -369,34 +369,6 @@ std::string ClientHandler::uploadFile(std::string path)
 	if (checkNameFile(fileName, path) == 1)
 		throw ConflictException();
 	path += "/" + fileName;
-	std::string contentType = this->request.getHttpHeaders()["content-type"];
-	if (contentType == "text/plain")
-	{
-		std::string filename = "text_plain.txt";
-
-		// Create an ofstream object to open the file in append mode
-		std::ofstream outfile;
-
-		// Open the file in append mode
-		outfile.open(filename.c_str(), std::ios::app); // std::ios::app opens the file for appending
-
-		// Check if the file is open
-		if (!outfile.is_open()) {
-			std::cerr << "Error opening file for writing." << std::endl;
-			return ""; // Return with an error code
-		}
-
-		// Data to append
-		std::string dataToAppend = this->request.getBodyContent();
-
-		// Write data to the file
-		outfile << dataToAppend;
-
-		// Close the file
-		outfile.close();
-
-		std::cout << "Data appended to " << filename << " successfully." << std::endl;
-	}
 	int file = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 	if (file < 0)
 		throw BadRequestException();
@@ -432,6 +404,8 @@ std::string ClientHandler::prepareResponse(struct Route route)
 	std::string method;
 	struct Route errorPage;
 
+	if (route.internal == true)
+		throw NotFoundException();
 	method = this->request.getHttpRequestLine()["method"];
 	if (method == "GET" && route.methods.count(method) > 0)
 	{
@@ -451,12 +425,6 @@ std::string ClientHandler::prepareResponse(struct Route route)
 	else
 		throw MethodNotAllowedException();
 	HttpResponse http(code, body);
-	if (route.uri.find("/images") != std::string::npos)
-	{
-		std::string file;
-		file = route.path.substr(route.path.find_last_of(".") + 1);
-		http.setImageType(file);
-	}
 	response = http.composeRespone();
 	return response;
 }

--- a/HttpResponse.cpp
+++ b/HttpResponse.cpp
@@ -95,42 +95,66 @@ std::string HttpResponse::generateHttpHeaders(void)
 	headers += "Content-Length: " + length + "\r\n";
 	timeStamp = findTimeStamp() + "\r\n";
 	headers += "Date: " + timeStamp;
-	headers += "Cache-Control: no-cache\r\n";
+	headers += "Cache-Control: no-store\r\n";
 	headers += "Connection: keep-alive\r\n";
 	return headers;
 }
 
+int HttpResponse::findFileType(std::string str)
+{
+	if (str.size() >= 2 && (static_cast<unsigned char>(str[0]) == 0xFF &&
+						static_cast<unsigned char>(str[1]) == 0xD8))
+		return 0; // JPEG
+	if (str.size() >= 8 && (static_cast<unsigned char>(str[0]) == 0x89 && 
+						static_cast<unsigned char>(str[1]) == 0x50 && 
+						static_cast<unsigned char>(str[2]) == 0x4E && 
+						static_cast<unsigned char>(str[3]) == 0x47 &&
+						static_cast<unsigned char>(str[4]) == 0x0D && 
+						static_cast<unsigned char>(str[5]) == 0x0A && 
+						static_cast<unsigned char>(str[6]) == 0x1A && 
+						static_cast<unsigned char>(str[7]) == 0x0A))
+		return 1; // PNG
+	if (str.size() >= 4 && (static_cast<unsigned char>(str[0]) == 0x47 && 
+						static_cast<unsigned char>(str[1]) == 0x49 && 
+						static_cast<unsigned char>(str[2]) == 0x46 && 
+						static_cast<unsigned char>(str[3]) == 0x38))
+		return 2; // GIF
+	// if (str.size() >= 12 && (static_cast<unsigned char>(str[0]) == 0x52 && 
+	// 					 static_cast<unsigned char>(str[1]) == 0x49 && 
+	// 					 static_cast<unsigned char>(str[2]) == 0x46 && 
+	// 					 static_cast<unsigned char>(str[3]) == 0x46 &&
+	// 					 static_cast<unsigned char>(str[8]) == 0x57 && 
+	// 					 static_cast<unsigned char>(str[9]) == 0x45 && 
+	// 					 static_cast<unsigned char>(str[10]) == 0x42 && 
+	// 					 static_cast<unsigned char>(str[11]) == 0x50))
+	// 	return 3; // WEMP
+	if (str.size() >= 4 && (static_cast<unsigned char>(str[0]) == 0x00 && 
+						static_cast<unsigned char>(str[1]) == 0x00 && 
+						static_cast<unsigned char>(str[2]) == 0x01 && 
+						static_cast<unsigned char>(str[3]) == 0x00))
+		return 3; // ICO
+	return 4;
+}
+
 std::string HttpResponse::findType(std::string str)
 {
-	int i = 0;
+	int magicNumber;
+
 	if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
 		return "text/html";
-	std::string	extensions[7] = {"jpg", "jpeg", "png", "gif", "bmp", "svg", "webp"};
-	for (;i < 7; i++)
-	{
-		if (extensions[i] == this->extension)
-			break;
-	}
-	switch (i)
+	magicNumber = findFileType(str);
+	switch (magicNumber)
 	{
 		case 0:
 			return "image/jpg";
 		case 1:
-			return "image/jpeg";
-		case 2:
 			return "image/png";
-		case 3:
+		case 2:
 			return "image/gif";
-		case 4:
-			return "image/bmp";
-		case 5:
-			return "image/svg";
-		case 6:
-			return "image/webp";
-		default:
+		case 3:
 			return "image/x-icon";
 	}
-	return "";
+	return "text/plain";
 }
 
 std::string HttpResponse::findTimeStamp(void)

--- a/HttpResponse.hpp
+++ b/HttpResponse.hpp
@@ -29,6 +29,7 @@ class HttpResponse {
 		std::string generateHttpHeaders();
 		std::string findType(std::string);
 		std::string findTimeStamp();
+		int			findFileType(std::string str);
 
 	private:
 		int			statusCode;


### PR DESCRIPTION
New logic to check content type of a file for finding the correct content type in the response: we can find html, images (based on bytes) and plain text.
We can retrieve images in upload folder and display on the webpage.
Example:
localhost:8080/upload/image.jpg
I also delete logic of text/plain upload because we didn't implement it.
Note: it caches /upload so it makes two requests, but it doesn't interfere with retrieve the file and display it.