### PR TITLE
CGI integration

### DIFF
--- a/CGI.cpp
+++ b/CGI.cpp
@@ -183,6 +183,7 @@ void CGI::populateEnvVariables(const HttpRequest& request)
 	_env_map["REDIRECT_STATUS"] = "200"; // Required for php-cgi with force-cgi-redirect
 	_env_map["SCRIPT_FILENAME"] = _cgi_path;
 	_env_map["FILE_NAME"] = getFileName(request.getHttpSection().myMap);
+	_env_map["MAX_CLIENT_BODY"] = _serverInfo.getSetting()["client_max_body_size"];
 	// Added now: DOCUMENT_ROOT environment variable
 	_env_map["DOCUMENT_ROOT"] = _serverInfo.getRoot();
 	Logger::debug("DOCUMENT_ROOT=" + _env_map["DOCUMENT_ROOT"]);

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -248,7 +248,16 @@ int ClientHandler::manageRequest()
 	int result;
 	std::string uri;
 	struct Route route;
-	result = readData(this->client_fd, this->raw_data, this->totbytes);
+	try
+	{
+		result = readData(this->client_fd, this->raw_data, this->totbytes);
+	}
+	catch(const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		exit(1);
+	}
+	
 	if (result == 0 || result == 1)
 		return 1;
 	else
@@ -332,14 +341,7 @@ int ClientHandler::retrieveResponse(void)
 	this->totbytes = 0;
 	this->request.cleanProperties();
 	this->startingTime = time(NULL);
-	int remove_fd = this->internal_fd;
-	if (this->internal_fd > 0)
-	{
-		Logger::debug("close fd if cgi");
-		close(this->internal_fd);
-		this->internal_fd = 0;
-	}
-	return remove_fd;
+	return this->internal_fd;
 }
 
 int ClientHandler::isCgi(std::string uri)

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -176,8 +176,8 @@ int ClientHandler::manageRequest(std::vector<pollfd> poll_sets)
 				int start = stringLowerCases.find("content-length") + 16;
 				int end = stringLowerCases.find("\r\n", this->raw_data.find("content-length"));
 				int bytes_expected = Utils::toInt(this->raw_data.substr(start, end - start));
-				if (bytes_expected > Utils::toInt(this->configInfo.getSetting()["client_max_body_size"]))
-					throw PayLoadTooLargeException();
+				// if (bytes_expected > Utils::toInt(this->configInfo.getSetting()["client_max_body_size"]))
+				// 	throw PayLoadTooLargeException();
 				if (this->totbytes < bytes_expected)
 					return 0;
 			}

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -254,16 +254,7 @@ int ClientHandler::manageRequest()
 	int result;
 	std::string uri;
 	struct Route route;
-	try
-	{
-		result = readData(this->client_fd, this->raw_data, this->totbytes);
-	}
-	catch(const std::exception& e)
-	{
-		std::cerr << e.what() << '\n';
-		exit(1);
-	}
-	
+	result = readData(this->client_fd, this->raw_data, this->totbytes);
 	if (result == 0 || result == 1)
 		return 1;
 	else
@@ -328,8 +319,10 @@ int ClientHandler::readData(int fd, std::string &str, int &bytes)
 	char buffer[BUFFER];
 
 	Utils::ft_memset(buffer, 0, sizeof(buffer));
+	Logger::error("buffer error memset");
 	res = recv(fd, buffer, BUFFER, MSG_DONTWAIT);
-	str.append(buffer, res);
+	if (res > 0)
+		str.append(buffer, res);
 	bytes += res;
 	if (res == 0)
 		return 0;
@@ -622,7 +615,7 @@ int ClientHandler::createResponse(void)
 	int code;
 
 	code = getStatusCode(this->raw_data);
-	HttpResponse http(code, this->raw_data);
+	HttpResponse http(200, this->raw_data);
 	
 	this->response = http.composeRespone();
 	return 2;

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -4,6 +4,7 @@
 
 #define INCOMPLETE 0
 //Constructor
+
 ClientHandler::ClientHandler(int fd, InfoServer const &configInfo)
 {
 	this->client_fd = fd;
@@ -161,7 +162,6 @@ std::string ClientHandler::createPath(struct Route route, std::string uri)
 void ClientHandler::validateHttpHeaders(struct Route route)
 {
 	std::string uri = this->request.getHttpRequestLine()["request-uri"];
-	route = this->configInfo.getRoute()[uri];
 	std::map<std::string, std::string> headers = this->request.getHttpHeaders();
 	std::map<std::string, std::string>::iterator it;
 	for (it = headers.begin(); it != headers.end(); it++)
@@ -179,7 +179,7 @@ void ClientHandler::validateHttpHeaders(struct Route route)
 			else
 				type = it->second;
 			std::map<std::string, std::string>::iterator itC;
-			for (itC = route.locSettings.begin(); itC != route.locSettings.end(); it++)
+			for (itC = route.locSettings.begin(); itC != route.locSettings.end(); itC++)
 			{
 				if (itC->first == "content_type")
 				{
@@ -229,36 +229,6 @@ int ClientHandler::checkRequestStatus(void)
 	return 1;
 }
 
-
-void ClientHandler::updateRoute(struct Route &route)
-{
-	if (route.locSettings.find("alias") != route.locSettings.end())
-	{
-		route.path.clear();
-		route.path += "." + route.locSettings.find("alias")->second;
-		int count = std::count(this->request.getUri().begin(), this->request.getUri().end(), '/');
-		if (count >= 2)
-		{
-			std::string copyUri = this->request.getUri();
-			copyUri.erase(0, 1);
-			size_t index = copyUri.find_first_of("/");
-			std::string file = copyUri.substr(index + 1);
-			route.path += "/" + file;
-		}
-		struct stat pathStat;
-		if (stat(route.path.c_str(), &pathStat) == 0)
-		{
-			if (S_ISDIR(pathStat.st_mode))
-			{
-				if (route.locSettings.find("default") != route.locSettings.end())
-				{
-					route.path += "/" + route.locSettings.find("default")->second;
-				}
-			}
-		}
-	}
-}
-
 void ClientHandler::redirectClient(struct Route &route)
 {
 	struct Route redirectRoute;
@@ -271,19 +241,6 @@ void ClientHandler::redirectClient(struct Route &route)
 	HttpResponse http(Utils::toInt(route.locSettings.find("status")->second), "");
 	http.setUriLocation(redirectRoute.uri);
 	this->response = http.composeRespone("");
-}
-
-void ClientHandler::findPath(std::string str, struct Route &route)
-{
-	std::string locationPath;
-	locationPath = findDirectory(str);
-	struct Route newRoute;
-	newRoute = this->configInfo.getRoute()[locationPath];
-	route = newRoute;
-	std::string newPath;
-	newPath = createPath(route, str);
-	route.path.clear();
-	route.path = newPath;
 }
 
 int ClientHandler::manageRequest()
@@ -381,29 +338,6 @@ int ClientHandler::retrieveResponse(void)
 	return this->internal_fd;
 }
 
-int ClientHandler::isCgi(std::string uri)
-{
-	if (uri == "/cgi-bin")
-		return true;
-	return false;
-}
-
-std::string ClientHandler::extractContent(std::string path)
-{
-	std::ifstream inputFile(path.c_str(), std::ios::binary);
-	if (!inputFile)
-		throw NotFoundException();
-	inputFile.seekg(0, std::ios::end);
-	std::streamsize size = inputFile.tellg();
-	inputFile.seekg(0, std::ios::beg);
-	std::string buffer;
-	buffer.resize(size);
-	if (!(inputFile.read(&buffer[0], size)))
-		throw NotFoundException();
-	inputFile.close();
-	return buffer;
-}
-
 std::string ClientHandler::retrievePage(struct Route route)
 {
 	std::string body;
@@ -419,66 +353,6 @@ std::string ClientHandler::retrievePage(struct Route route)
 	}
 	body = extractContent(route.path);
 	return body;
-}
-
-std::string getFileType(std::map<std::string, std::string> headers)
-{
-	std::map<std::string, std::string>::iterator it;
-	std::string type;
-
-	for (it = headers.begin(); it != headers.end(); it++)
-	{
-		if (it->first == "content-type")
-			type = it->second;
-	}
-	return type;
-}
-
-std::string getFileName(std::map<std::string, std::string> headers)
-{
-	std::map<std::string, std::string>::iterator it;
-	std::string name;
-
-	for (it = headers.begin(); it != headers.end(); it++)
-	{
-		if (it->first == "content-disposition")
-		{
-			if (it->second.find("filename") != std::string::npos)
-			{
-				std::string fileNameField = it->second.substr(it->second.find("filename"));
-				if (fileNameField.find('"') != std::string::npos)
-				{
-					int indexFirstQuote = fileNameField.find('"');
-					int indexSecondQuote = 0;
-					if (fileNameField.find('"', indexFirstQuote+1) != std::string::npos)
-					{
-						indexSecondQuote = fileNameField.find('"', indexFirstQuote+1);
-					}
-					name = fileNameField.substr(indexFirstQuote+1,indexSecondQuote - indexFirstQuote-1);
-				}
-			}
-		}
-	}
-	return name;
-}
-
-int checkNameFile(std::string str, std::string path)
-{
-	DIR *folder;
-	struct dirent *data;
-
-	folder = opendir(path.c_str());
-	std::string convStr;
-	if (folder == NULL)
-		throw NotFoundException();
-	while ((data = readdir(folder)))
-	{
-		convStr = data->d_name;
-		if (convStr == str)
-			return (1);
-	}
-	closedir(folder);
-	return (0);
 }
 
 std::string ClientHandler::uploadFile(std::string path)
@@ -593,38 +467,10 @@ int ClientHandler::createResponse(void)
 		std::string headers;
 
 		size_t index_new_line = this->raw_data.find("\n\n");
-		if (index_new_line != std::string::npos) //there are headers
+		if (index_new_line != std::string::npos)
 		{
-			size_t index_status = this->raw_data.find("Status");
-			std::string statusLine;
-			size_t index_end_line;
-			size_t index_start_number;
-			size_t index_end_number;
-			std::string codeStr;
-			if (index_status == std::string::npos)
-			{
-				if (this->request.getMethod() == "POST")
-					code = 201;
-				else
-					code = 200;
-			}
-			else
-			{
-				index_end_line = this->raw_data.find("\n");
-				if (index_end_line == std::string::npos)
-					throw ServiceUnavailabledException();
-				statusLine = this->raw_data.substr(index_status, index_end_line);
-				index_start_number = statusLine.find(" ");
-				if (index_start_number == std::string::npos)
-					throw ServiceUnavailabledException();
-				statusLine = statusLine.substr(index_start_number + 1);
-				index_end_number = statusLine.find(" ");
-				if (index_end_number == std::string::npos)
-					throw ServiceUnavailabledException();
-				codeStr = statusLine.substr(0, index_end_line - 1);
-				code = Utils::toInt(codeStr);
-			}
-			headers = this->raw_data.substr(0, index_new_line + 2); //include \n\n
+			code = extractStatusCode(this->raw_data, this->request.getMethod());
+			headers = this->raw_data.substr(0, index_new_line + 2);
 			body = this->raw_data.substr(index_new_line + 2);
 		}
 		else

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -37,6 +37,12 @@ class ClientHandler {
 		double 		getTimeOut(void) const;
 		HttpRequest	getRequest(void) const;
 		std::string getResponse(void) const;
+		std::string getRawData() const {return raw_data;}
+		int			checkRequestStatus(void);
+		void		redirectClient(struct Route &route);
+		void 		findPath(std::string str, struct Route &route);
+		void		updateRoute(struct Route &route);
+		int			readStdout(int fd);
 		void		resetCGIFD(void);
 		void		setResponse(std::string);
 		int 		manageRequest(std::vector<pollfd> poll_sets);
@@ -49,6 +55,7 @@ class ClientHandler {
 		std::string uploadFile(std::string path);
 		std::string deleteFile(std::string path);
 		std::string prepareResponse(struct Route route);
+		int 		createResponse(void);
 		int			retrieveResponse(void);
 		int 		isCgi(std::string str);
 

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -45,7 +45,7 @@ class ClientHandler {
 		int			readStdout(int fd);
 		void		resetCGIFD(void);
 		void		setResponse(std::string);
-		int 		manageRequest(std::vector<pollfd> poll_sets);
+		int 		manageRequest(void);
 		int 		readData(int fd, std::string &str, int &bytes);
 		std::string findDirectory(std::string uri);
 		std::string createPath(struct Route route, std::string uri);

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -53,7 +53,7 @@ class ClientHandler {
 		int 		isCgi(std::string str);
 
 	private:
-	int 		fd;
+	int 		client_fd;
 	int 		totbytes;
 	std::string raw_data;
 	double		startingTime;
@@ -61,7 +61,7 @@ class ClientHandler {
 	InfoServer	configInfo;
 	HttpRequest request;
 	std::string response;
-	int			cgi_fd;
+	int			internal_fd;
 };
 
 #endif

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -58,7 +58,6 @@ class ClientHandler {
 		int 		createResponse(void);
 		int			retrieveResponse(void);
 		int 		isCgi(std::string str);
-		std::map<std::string, std::string>		parseScriptHeaders(void);
 
 	private:
 	int 		client_fd;
@@ -72,5 +71,10 @@ class ClientHandler {
 	int			internal_fd;
 	int			pid;
 };
+
+int			checkNameFile(std::string str, std::string path);
+std::string	getFileName(std::map<std::string, std::string> headers);
+std::string	getFileType(std::map<std::string, std::string> headers);
+int 		extractStatusCode(std::string str, std::string method);
 
 #endif

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -35,6 +35,7 @@ class ClientHandler {
 		int 		getCGI_Fd(void) const;
 		double 		getTime(void) const;
 		double 		getTimeOut(void) const;
+		int 		getPid(void) const;
 		HttpRequest	getRequest(void) const;
 		std::string getResponse(void) const;
 		std::string getRawData() const {return raw_data;}
@@ -43,7 +44,6 @@ class ClientHandler {
 		void 		findPath(std::string str, struct Route &route);
 		void		updateRoute(struct Route &route);
 		int			readStdout(int fd);
-		void		resetCGIFD(void);
 		void		setResponse(std::string);
 		int 		manageRequest(void);
 		int 		readData(int fd, std::string &str, int &bytes);
@@ -69,6 +69,7 @@ class ClientHandler {
 	HttpRequest request;
 	std::string response;
 	int			internal_fd;
+	int			pid;
 };
 
 #endif

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -58,6 +58,7 @@ class ClientHandler {
 		int 		createResponse(void);
 		int			retrieveResponse(void);
 		int 		isCgi(std::string str);
+		std::map<std::string, std::string>		parseScriptHeaders(void);
 
 	private:
 	int 		client_fd;

--- a/ClientHandlerUtils.cpp
+++ b/ClientHandlerUtils.cpp
@@ -1,0 +1,216 @@
+#include "ClientHandler.hpp"
+
+std::string ClientHandler::findDirectory(std::string uri)
+{
+	struct Route route;
+	size_t index;
+	route = this->configInfo.getRoute()[uri];
+	if (route.path.empty())
+	{
+		index = uri.find(".");
+		if (index != std::string::npos)
+		{
+			index = uri.find_last_of("/");
+			uri = uri.substr(0, index);
+			route = this->configInfo.getRoute()[uri];
+			if (!route.path.empty())
+				return uri;
+		}
+		while (uri.size() > 1)
+		{
+			index = uri.find_last_of("/");
+			if (index != std::string::npos)
+				uri = uri.substr(0, index);
+			else
+				break;
+			route = this->configInfo.getRoute()[uri];
+			if (!(route.path.empty()))
+				return uri;
+		}
+	}
+	else
+		return (uri);
+	return "/";
+}
+
+std::string ClientHandler::createPath(struct Route route, std::string uri)
+{
+	std::string lastItem;
+	std::string path = route.path;
+	std::string defaultFile = route.locSettings["index"];
+	size_t index;
+
+	if (path == "/")
+		return "";
+	if (path[path.size() - 1] == '/')
+		path.erase(path.size() - 1, 1);
+	index = uri.find_last_of("/");
+	if (index != std::string::npos)
+		lastItem = uri.substr(index + 1);
+	if (defaultFile.empty())
+		path += "/" + lastItem;
+	else
+		path += uri;
+	return path;
+}
+
+void ClientHandler::updateRoute(struct Route &route)
+{
+	if (route.locSettings.find("alias") != route.locSettings.end())
+	{
+		route.path.clear();
+		route.path += "." + route.locSettings.find("alias")->second;
+		int count = std::count(this->request.getUri().begin(), this->request.getUri().end(), '/');
+		if (count >= 2)
+		{
+			std::string copyUri = this->request.getUri();
+			copyUri.erase(0, 1);
+			size_t index = copyUri.find_first_of("/");
+			std::string file = copyUri.substr(index + 1);
+			route.path += "/" + file;
+		}
+		struct stat pathStat;
+		if (stat(route.path.c_str(), &pathStat) == 0)
+		{
+			if (S_ISDIR(pathStat.st_mode))
+			{
+				if (route.locSettings.find("default") != route.locSettings.end())
+				{
+					route.path += "/" + route.locSettings.find("default")->second;
+				}
+			}
+		}
+	}
+}
+
+void ClientHandler::findPath(std::string str, struct Route &route)
+{
+	std::string locationPath;
+	locationPath = findDirectory(str);
+	struct Route newRoute;
+	newRoute = this->configInfo.getRoute()[locationPath];
+	route = newRoute;
+	std::string newPath;
+	newPath = createPath(route, str);
+	route.path.clear();
+	route.path = newPath;
+}
+
+std::string ClientHandler::extractContent(std::string path)
+{
+	std::ifstream inputFile(path.c_str(), std::ios::binary);
+	if (!inputFile)
+		throw NotFoundException();
+	inputFile.seekg(0, std::ios::end);
+	std::streamsize size = inputFile.tellg();
+	inputFile.seekg(0, std::ios::beg);
+	std::string buffer;
+	buffer.resize(size);
+	if (!(inputFile.read(&buffer[0], size)))
+		throw NotFoundException();
+	inputFile.close();
+	return buffer;
+}
+
+int ClientHandler::isCgi(std::string uri)
+{
+	if (uri == "/cgi-bin")
+		return true;
+	return false;
+}
+
+std::string getFileType(std::map<std::string, std::string> headers)
+{
+	std::map<std::string, std::string>::iterator it;
+	std::string type;
+
+	for (it = headers.begin(); it != headers.end(); it++)
+	{
+		if (it->first == "content-type")
+			type = it->second;
+	}
+	return type;
+}
+
+std::string getFileName(std::map<std::string, std::string> headers)
+{
+	std::map<std::string, std::string>::iterator it;
+	std::string name;
+
+	for (it = headers.begin(); it != headers.end(); it++)
+	{
+		if (it->first == "content-disposition")
+		{
+			if (it->second.find("filename") != std::string::npos)
+			{
+				std::string fileNameField = it->second.substr(it->second.find("filename"));
+				if (fileNameField.find('"') != std::string::npos)
+				{
+					int indexFirstQuote = fileNameField.find('"');
+					int indexSecondQuote = 0;
+					if (fileNameField.find('"', indexFirstQuote+1) != std::string::npos)
+					{
+						indexSecondQuote = fileNameField.find('"', indexFirstQuote+1);
+					}
+					name = fileNameField.substr(indexFirstQuote+1,indexSecondQuote - indexFirstQuote-1);
+				}
+			}
+		}
+	}
+	return name;
+}
+
+int checkNameFile(std::string str, std::string path)
+{
+	DIR *folder;
+	struct dirent *data;
+
+	folder = opendir(path.c_str());
+	std::string convStr;
+	if (folder == NULL)
+		throw NotFoundException();
+	while ((data = readdir(folder)))
+	{
+		convStr = data->d_name;
+		if (convStr == str)
+			return (1);
+	}
+	closedir(folder);
+	return (0);
+}
+
+int extractStatusCode(std::string str, std::string method)
+{
+	size_t index_status = str.find("Status");
+	std::string statusLine;
+	size_t index_end_line;
+	size_t index_start_number;
+	size_t index_end_number;
+	std::string codeStr;
+	int code = 0;
+	
+	if (index_status == std::string::npos)
+	{
+		if (method == "POST")
+			code = 201;
+		else
+			code = 200;
+	}
+	else
+	{
+		index_end_line = str.find("\n");
+		if (index_end_line == std::string::npos)
+			throw ServiceUnavailabledException();
+		statusLine = str.substr(index_status, index_end_line);
+		index_start_number = statusLine.find(" ");
+		if (index_start_number == std::string::npos)
+			throw ServiceUnavailabledException();
+		statusLine = statusLine.substr(index_start_number + 1);
+		index_end_number = statusLine.find(" ");
+		if (index_end_number == std::string::npos)
+			throw ServiceUnavailabledException();
+		codeStr = statusLine.substr(0, index_end_line - 1);
+		code = Utils::toInt(codeStr);
+	}
+	return code;
+}

--- a/HttpRequest.cpp
+++ b/HttpRequest.cpp
@@ -16,6 +16,7 @@ HttpRequest::HttpRequest(HttpRequest const &other)
 	this->headers = other.headers;
 	this->sectionInfo = other.sectionInfo;
 	this->body = other.body;
+	this->scriptName = other.scriptName;
 }
 
 // Setters and Getters
@@ -95,6 +96,11 @@ std::string HttpRequest::getBodyContent(void) const
 	return this->body;
 }
 
+std::string HttpRequest::getScriptName(void) const
+{
+	return this->scriptName;
+}
+
 // Main functions
 
 void HttpRequest::HttpParse(std::string str, int size)
@@ -151,6 +157,7 @@ void HttpRequest::setExtraHeaders(void)
 	it = this->headers.find("content-length");
 	this->body = this->sectionInfo.body;
 }
+
 void HttpRequest::parseRequestHttp(void)
 {
 	std::string inputString(this->str);

--- a/HttpRequest.hpp
+++ b/HttpRequest.hpp
@@ -46,7 +46,7 @@ class HttpRequest {
 		// std::string							getRemoteHost(void) const;
 		std::string 						getHost(void) const;
 		std::string 						getProtocol(void) const;
-		// std::string							getScriptName(void) const;
+		std::string							getScriptName(void) const;
 		// std::string							getServerPort(void)const;
 		// std::string							getServerProtocol(void) const;
 		std::string							findValue(std::map<std::string, std::string> map, std::string key) const;
@@ -74,6 +74,7 @@ class HttpRequest {
 		struct section						sectionInfo;
 		std::string							body;
 		std::string							content_type;
+		std::string							scriptName;
 };
 
 std::ostream &operator<<(std::ostream &output, HttpRequest const &request);

--- a/HttpResponse.cpp
+++ b/HttpResponse.cpp
@@ -54,9 +54,25 @@ std::string HttpResponse::composeRespone(void)
 	std::string statusLine;
 	std::string headers;
 
+
 	statusLine = generateStatusLine(this->statusCode);
 	response += statusLine;
 	headers = generateHttpHeaders();
+	response += headers + "\r\n";
+	response += this->body;
+	return response;
+}
+
+std::string HttpResponse::composeRespone(std::string str)
+{
+	std::string response;
+	std::string statusLine;
+	std::string headers;
+
+	
+	statusLine = generateStatusLine(this->statusCode);
+	response += statusLine;
+	headers = str + "\r\n";
 	response += headers + "\r\n";
 	response += this->body;
 	return response;

--- a/HttpResponse.cpp
+++ b/HttpResponse.cpp
@@ -48,20 +48,20 @@ void HttpResponse::setUriLocation(std::string url)
 }
 
 // Main functions
-std::string HttpResponse::composeRespone(void)
-{
-	std::string response;
-	std::string statusLine;
-	std::string headers;
+// std::string HttpResponse::composeRespone(void)
+// {
+// 	std::string response;
+// 	std::string statusLine;
+// 	std::string headers;
 
 
-	statusLine = generateStatusLine(this->statusCode);
-	response += statusLine;
-	headers = generateHttpHeaders();
-	response += headers + "\r\n";
-	response += this->body;
-	return response;
-}
+// 	statusLine = generateStatusLine(this->statusCode);
+// 	response += statusLine;
+// 	headers = generateHttpHeaders();
+// 	response += headers + "\r\n";
+// 	response += this->body;
+// 	return response;
+// }
 
 std::string HttpResponse::composeRespone(std::string str)
 {
@@ -72,7 +72,10 @@ std::string HttpResponse::composeRespone(std::string str)
 	
 	statusLine = generateStatusLine(this->statusCode);
 	response += statusLine;
-	headers = str + "\r\n";
+	if (!str.empty())
+		headers = str + "\r\n";
+	else
+		headers = generateHttpHeaders();
 	response += headers + "\r\n";
 	response += this->body;
 	return response;

--- a/HttpResponse.cpp
+++ b/HttpResponse.cpp
@@ -115,15 +115,6 @@ int HttpResponse::findFileType(std::string str)
 						static_cast<unsigned char>(str[2]) == 0x46 && 
 						static_cast<unsigned char>(str[3]) == 0x38))
 		return 2; // GIF
-	// if (str.size() >= 12 && (static_cast<unsigned char>(str[0]) == 0x52 && 
-	// 					 static_cast<unsigned char>(str[1]) == 0x49 && 
-	// 					 static_cast<unsigned char>(str[2]) == 0x46 && 
-	// 					 static_cast<unsigned char>(str[3]) == 0x46 &&
-	// 					 static_cast<unsigned char>(str[8]) == 0x57 && 
-	// 					 static_cast<unsigned char>(str[9]) == 0x45 && 
-	// 					 static_cast<unsigned char>(str[10]) == 0x42 && 
-	// 					 static_cast<unsigned char>(str[11]) == 0x50))
-	// 	return 3; // WEMP
 	if (str.size() >= 4 && (static_cast<unsigned char>(str[0]) == 0x00 && 
 						static_cast<unsigned char>(str[1]) == 0x00 && 
 						static_cast<unsigned char>(str[2]) == 0x01 && 
@@ -138,6 +129,8 @@ std::string HttpResponse::findType(std::string str)
 
 	if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
 		return "text/html";
+	else if (str[1] == '{')
+		return "application/json";
 	magicNumber = findFileType(str);
 	switch (magicNumber)
 	{

--- a/HttpResponse.hpp
+++ b/HttpResponse.hpp
@@ -29,6 +29,7 @@ class HttpResponse {
 		std::string findType(std::string);
 		std::string findTimeStamp();
 		int			findFileType(std::string str);
+		std::string composeRespone(std::string str);
 
 	private:
 		int							statusCode;

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ OBJ_DIR = obj
 CPP_FILES = ServerSockets.cpp main.cpp HttpResponse.cpp \
 			WebServer.cpp HttpRequest.cpp Logger.cpp \
 			ClientHandler.cpp Config.cpp InfoServer.cpp \
-			HttpException.cpp CGI.cpp
+			HttpException.cpp CGI.cpp ClientHandlerUtils.cpp
 CPP_OBJ = $(OBJ_DIR)/ServerSockets.o $(OBJ_DIR)/main.o \
           $(OBJ_DIR)/HttpResponse.o \
           $(OBJ_DIR)/Logger.o \
 		  $(OBJ_DIR)/WebServer.o $(OBJ_DIR)/HttpRequest.o \
 		  $(OBJ_DIR)/ClientHandler.o  $(OBJ_DIR)/Config.o \
 		  $(OBJ_DIR)/InfoServer.o $(OBJ_DIR)/HttpException.o \
-		  $(OBJ_DIR)/CGI.o
+		  $(OBJ_DIR)/CGI.o $(OBJ_DIR)/ClientHandlerUtils.o
 
 NAME = webserver
 

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -6,11 +6,6 @@
 #define DONE 2
 
 // Constructor and Destructor
-typedef struct m_pid
-{
-	int cgi_fd;
-	int clent_fd;
-} t_pid;
 
 Webserver::Webserver(Config& file)
 {

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -120,7 +120,9 @@ std::string responseType(std::string str)
 
 	if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
 		return "text/html";
-	return "application/json";
+	else if (str[1] == '{')
+		return "application/json";
+	return "text/plain";
 }
 
 std::string timeStamp(void)
@@ -136,7 +138,7 @@ std::string timeStamp(void)
 std::string findStatusCode(std::string str)
 {
 	if (str.find("ok") != std::string::npos)
-		return "200";
+		return "201";
 	else if (str.find("conflict") != std::string::npos)
 		return "409";
 	else if (str.find("payload too large") != std::string::npos)
@@ -146,8 +148,8 @@ std::string findStatusCode(std::string str)
 
 std::string findStaus(std::string str)
 {
-	if (str == "200")
-		return "OK";
+	if (str == "201")
+		return "CREATED";
 	else if (str == "409")
 		return "CONFLICT";
 	else if (str == "413")
@@ -183,14 +185,40 @@ void Webserver::dispatchEvents()
 						break;
 					html_page.append(buffer, res);
 				}
-				std::string response_process = "HTTP/1.1 " + findStatusCode(html_page) + " " + findStaus(findStatusCode(html_page)) + "\r\n";
-				response_process += "Content-Type: " + responseType(html_page) + "\r\n";
-				response_process += "Content-Lenght: " + Utils::toString(html_page.size()) + "\r\n";
-				std::string	time = timeStamp();
-				response_process += "Date: " + time + "\r\n";
-				response_process += "Cache-Control: no-store\r\n";
-				response_process += "Connection: keep-alive\r\n";
-				response_process += html_page;
+				std::string response_process;
+				if (responseType(html_page) == "application/json")
+				{
+					response_process = "HTTP/1.1 " + findStatusCode(html_page) + " " + findStaus(findStatusCode(html_page)) + "\r\n";
+					response_process += "Content-Type: " + responseType(html_page) + "\r\n";
+					response_process += "Content-Lenght: " + Utils::toString(html_page.size()) + "\r\n";
+					std::string	time = timeStamp();
+					response_process += "Date: " + time + "\r\n";
+					response_process += "Cache-Control: no-store\r\n";
+					response_process += "Connection: keep-alive\r\n";
+					response_process += html_page;
+				}
+				else if (responseType(html_page) == "text/html")
+				{
+					response_process = "HTTP/1.1 200 OK\r\n";
+					response_process += "Content-Type: " + responseType(html_page) + "\r\n";
+					response_process += "Content-Lenght: " + Utils::toString(html_page.size()) + "\r\n";
+					std::string	time = timeStamp();
+					response_process += "Date: " + time + "\r\n";
+					response_process += "Cache-Control: no-store\r\n";
+					response_process += "Connection: keep-alive\r\n\r\n";
+					response_process += html_page;
+				}
+				else
+				{
+					response_process = "HTTP/1.1 200 OK\r\n";
+					response_process += "Content-Type: " + responseType(html_page) + "\r\n";
+					response_process += "Content-Lenght: " + Utils::toString(html_page.size()) + "\r\n";
+					std::string	time = timeStamp();
+					response_process += "Date: " + time + "\r\n";
+					response_process += "Cache-Control: no-store\r\n";
+					response_process += "Connection: keep-alive\r\n\r\n";
+					response_process += html_page;
+				}
 				Logger::debug("Response_process: " + response_process);
 
 				// Get the client fd associated with this CGI process

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -114,6 +114,25 @@ int	Webserver::startServer()
 	return 0;
 }
 
+std::string responseType(std::string str)
+{
+	int magicNumber;
+
+	if (str.find("<html") != std::string::npos || str.find("<!DOCTYPE") != std::string::npos)
+		return "text/html";
+	return "application/json";
+}
+
+std::string timeStamp(void)
+{
+	std::time_t result = std::time(NULL);
+	std::tm *localtime = std::localtime(&result);
+	char *time = std::asctime(localtime);
+	time[strlen(time) - 1] = '\0';
+	std::string str(time);
+	return str;
+}
+
 void Webserver::dispatchEvents()
 {
 	std::vector<struct pollfd>::iterator it;
@@ -132,8 +151,6 @@ void Webserver::dispatchEvents()
 			{
 				Logger::info("Start CGI logic here");
 				std::string response_process = "HTTP/1.1 200 OK\r\n";
-				response_process += "Content-Type: application/json\r\n";
-				response_process += "Connection: keep-alive\r\n";
 				char buffer[5000];
 				std::string html_page;
 				int res;
@@ -148,8 +165,13 @@ void Webserver::dispatchEvents()
 				}
 				// ssize_t bytesRead = read(it->fd, buffer, sizeof(buffer) - 1);
 				// std::string str(buffer);
-				response_process += "Content-Lenght: " + Utils::toString(html_page.size());
-				response_process += "\r\n"; // End of headers
+				response_process += "Content-Type: " + responseType(html_page) + "\r\n";
+				response_process += "Content-Lenght: " + Utils::toString(html_page.size()) + "\r\n";
+				std::string	time = timeStamp();
+				response_process += "Date: " + time + "\r\n";
+				response_process += "Cache-Control: no-store\r\n";
+				response_process += "Connection: keep-alive\r\n";
+				// response_process += "\r\n"; // End of headers
 				response_process += html_page;
 				Logger::debug("Response_process: " + response_process);
 

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -133,6 +133,28 @@ std::string timeStamp(void)
 	return str;
 }
 
+std::string findStatusCode(std::string str)
+{
+	if (str.find("ok") != std::string::npos)
+		return "200";
+	else if (str.find("conflict") != std::string::npos)
+		return "409";
+	else if (str.find("payload too large") != std::string::npos)
+		return "413";
+	return "500";
+}
+
+std::string findStaus(std::string str)
+{
+	if (str == "200")
+		return "OK";
+	else if (str == "409")
+		return "CONFLICT";
+	else if (str == "413")
+		return "PAYLOAD TOO LARGE";
+	return "SERVER INTERNAL ERROR";
+}
+
 void Webserver::dispatchEvents()
 {
 	std::vector<struct pollfd>::iterator it;
@@ -150,7 +172,6 @@ void Webserver::dispatchEvents()
 			else if (fdIsCGI(it->fd) == true)
 			{
 				Logger::info("Start CGI logic here");
-				std::string response_process = "HTTP/1.1 200 OK\r\n";
 				char buffer[5000];
 				std::string html_page;
 				int res;
@@ -161,17 +182,14 @@ void Webserver::dispatchEvents()
 					if (res <= 0)
 						break;
 					html_page.append(buffer, res);
-					// bytes += res;
 				}
-				// ssize_t bytesRead = read(it->fd, buffer, sizeof(buffer) - 1);
-				// std::string str(buffer);
+				std::string response_process = "HTTP/1.1 " + findStatusCode(html_page) + " " + findStaus(findStatusCode(html_page)) + "\r\n";
 				response_process += "Content-Type: " + responseType(html_page) + "\r\n";
 				response_process += "Content-Lenght: " + Utils::toString(html_page.size()) + "\r\n";
 				std::string	time = timeStamp();
 				response_process += "Date: " + time + "\r\n";
 				response_process += "Cache-Control: no-store\r\n";
 				response_process += "Connection: keep-alive\r\n";
-				// response_process += "\r\n"; // End of headers
 				response_process += html_page;
 				Logger::debug("Response_process: " + response_process);
 

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -129,7 +129,7 @@ void Webserver::dispatchEvents()
 			result = -2;
 			Logger::error("result: " + Utils::toString(result));
 			Logger::error("client fd: " + Utils::toString(it->fd));
-			result = processClient(it->fd, WRITE) == -1;
+			result = processClient(it->fd, WRITE);
 			Logger::error("result after processClient: " + Utils::toString(result));
 			Logger::error("fd: " + Utils::toString(it->fd));
 			if (result == -1)

--- a/WebServer.hpp
+++ b/WebServer.hpp
@@ -46,6 +46,7 @@ class Webserver {
         void                                    dispatchEvents(void);
         void                                    createNewClient(int fd);
         int                                     processClient(int fd, int event);
+        int                                     processCGI(int fd);
         void                                    closeSockets(void);
         std::vector<ClientHandler>::iterator    retrieveClient(int fd);
         std::vector<ClientHandler>::iterator    retrieveClientCGI(int fd);

--- a/default.conf
+++ b/default.conf
@@ -3,7 +3,7 @@ server {
 	server_name				localhost;
 	root					/www;
 	error_path				/www/errors;
-	client_max_body_size	10000000;
+	client_max_body_size	1;
 	keepalive_timeout		75;
 	cgi_processing_timeout	15;
 

--- a/www/cgi-bin/upload.py
+++ b/www/cgi-bin/upload.py
@@ -23,8 +23,8 @@ ERROR_MESSAGES = {
 }
 
 def send_json_response(status_code, status, message):
-    print(f"Status: {status_code} {status}")
-    print("Content-Type: application/json")
+    # print(f"Status: {status_code} {status}")
+    # print("Content-Type: application/json")
     print()
     response = {"status": status.lower(), "message": message}
     print(json.dumps(response))

--- a/www/cgi-bin/upload.py
+++ b/www/cgi-bin/upload.py
@@ -31,13 +31,15 @@ def send_json_response(status_code, status, message):
     sys.exit(0)
 
 def save_uploaded_file(upload_dir):
-    logging.debug("All environment variables: %s" % os.environ)
-    logging.debug("CONTENT_LENGTH: %s" % os.environ.get("CONTENT_LENGTH", "unset"))
-    logging.debug("CONTENT_TYPE: %s" % os.environ.get("CONTENT_TYPE", "unset"))
-    logging.debug("REQUEST_METHOD: %s" % os.environ.get("REQUEST_METHOD", "unset"))
+    # logging.debug("All environment variables: %s" % os.environ)
+    # logging.debug("CONTENT_LENGTH: %s" % os.environ.get("CONTENT_LENGTH", "unset"))
+    # logging.debug("CONTENT_TYPE: %s" % os.environ.get("CONTENT_TYPE", "unset"))
+    # logging.debug("REQUEST_METHOD: %s" % os.environ.get("REQUEST_METHOD", "unset"))
 
     # Check content length against client_max_body_size from environment
     content_length = int(os.environ.get("CONTENT_LENGTH", 0))
+    if content_length > int(os.environ.get("MAX_CLIENT_BODY", 0)):
+        send_json_response(413, "Payload Too Large", ERROR_MESSAGES[413])
     # get and check content type to either read string or
     raw_input = sys.stdin.buffer.read(content_length)
     logging.debug("Raw stdin length: %d" % len(raw_input))
@@ -75,9 +77,6 @@ def save_uploaded_file(upload_dir):
     # Check directory writability
     if not os.access(abs_upload_dir, os.W_OK):
         send_json_response(403, "Forbidden", "Forbidden: No Write Vibes Here!")
-    #Check payload
-    if content_length > int(os.environ.get("MAX_CLIENT_BODY", 0)):
-        send_json_response(413, "Payload Too Large", ERROR_MESSAGES[413])
     # Set target filename and check for conflict
     filename = os.environ.get("FILE_NAME")
     full_filename = os.path.join(abs_upload_dir, os.path.basename(filename))

--- a/www/cgi-bin/upload.py
+++ b/www/cgi-bin/upload.py
@@ -23,8 +23,8 @@ ERROR_MESSAGES = {
 }
 
 def send_json_response(status_code, status, message):
-    # print(f"Status: {status_code} {status}")
-    # print("Content-Type: application/json")
+    print(f"Status: {status_code} {status}")
+    print("Content-Type: application/json")
     print()
     response = {"status": status.lower(), "message": message}
     print(json.dumps(response))
@@ -100,7 +100,7 @@ def save_uploaded_file(upload_dir):
         logging.debug("File exists after write: %s" % os.path.exists(filename))
 
         # Success response
-        send_json_response(200, "OK", "Upload Grooved to Perfection, Baby!")
+        send_json_response(201, "CREATED", "Upload Grooved to Perfection, Baby!")
     except Exception as e:
         logging.debug("Error processing file: %s" % str(e))
         send_json_response(500, "Internal Server Error", ERROR_MESSAGES[500])

--- a/www/cgi-bin/upload.py
+++ b/www/cgi-bin/upload.py
@@ -75,7 +75,9 @@ def save_uploaded_file(upload_dir):
     # Check directory writability
     if not os.access(abs_upload_dir, os.W_OK):
         send_json_response(403, "Forbidden", "Forbidden: No Write Vibes Here!")
-
+    #Check payload
+    if content_length > int(os.environ.get("MAX_CLIENT_BODY", 0)):
+        send_json_response(413, "Payload Too Large", ERROR_MESSAGES[413])
     # Set target filename and check for conflict
     filename = os.environ.get("FILE_NAME")
     full_filename = os.path.join(abs_upload_dir, os.path.basename(filename))

--- a/www/static/index.html
+++ b/www/static/index.html
@@ -279,8 +279,8 @@
                                 console.error('JSON parsing failed:', e);
                                 throw new Error('Invalid JSON response: ' + jsonText);
                             }
-                            if (data.status === 201 && jsonData.status === 'ok') {
-                                console.log('Success case: 200 OK');
+                            if (data.status === 201 && jsonData.status === 'created') {
+                                console.log('Success case: 201 CREATED');
                                 successMsg.textContent = jsonData.message;
                                 successMsg.style.display = 'block';
                                 setTimeout(() => successMsg.style.display = 'none', 3000);

--- a/www/static/index.html
+++ b/www/static/index.html
@@ -279,7 +279,7 @@
                                 console.error('JSON parsing failed:', e);
                                 throw new Error('Invalid JSON response: ' + jsonText);
                             }
-                            if (data.status === 200 && jsonData.status === 'ok') {
+                            if (data.status === 201 && jsonData.status === 'ok') {
                                 console.log('Success case: 200 OK');
                                 successMsg.textContent = jsonData.message;
                                 successMsg.style.display = 'block';
@@ -289,7 +289,13 @@
                                 successMsg.textContent = jsonData.message;
                                 successMsg.style.display = 'block';
                                 setTimeout(() => successMsg.style.display = 'none', 3000);
-                            } else {
+                            } else if (data.status === 413 && jsonData.status === 'payload too large') {
+                                console.log('Payload Too Large case: 413 Payload Too Large detected in CGI');
+                                successMsg.textContent = jsonData.message;
+                                successMsg.style.display = 'block';
+                                setTimeout(() => successMsg.style.display = 'none', 3000);
+                            }
+                            else {
                                 console.log('Unexpected JSON status:', data.status, 'with jsonData.status:', jsonData.status);
                                 throw new Error('Unexpected JSON response status: ' + data.status);
                             }


### PR DESCRIPTION
Full CGI integration. On this branch, you can find these implementations:

**_Configuration file_**
-add two fields in the cgi-block:
```
upload_dir		/www/upload;
content_type	text/html text/plain image/jpg image/png image/jpeg;
```
to retrieve location where to upload and check the content type

**_CGI class_**

- passing request to get information to set environment variables and argument for executing the script
- creation of two pipes: one pipe for the server to read from the child (so read stdout) and one pipe for the child to write to the server (write on stdin)
- start child process with fork and execute the script

**_ClientHandler class_**

- add pid and and internal_fd properties to retrieve the pid of the child process and the fd of the pipe to read from
- validateHttpHeaders: added checks that can be done for both static and cgi just once (content type, method, http version)
- Resize ManageRequest
- check for cgi script existence before creating the cgi object
- readData: removed the while loop to recv since poll can do it (the while loop would have blocked if very big file to read)
- add ReadStdout to read the output of the script 
- add createResponse: to create the http headers for script response (I think it can be done one implementation with the one existing)
- Move helper functions into ClientHandlerUtils to better readability

**_ClientHandlerUtils class_**
- just add functions from ClientHandler that I consider being helper functions, so ClientHandler is more readable

**_HttpResponse class_**

- add 418 as error in the map (but I don't know how to understand the code from the php file)
- composeResponse now takes a parameter: the presence of headers in the script or empty string if not. Not sure if just using the one from the scripts or add more

**_WebServer class_**

- checkTime:  I think we only need one timeout. It still checks in seconds, but it can change. It also checks if the client had an open cgi and close it by sending SIGNTERM
- add isFdCGI: cgi fd is now a property of clienthandler, so we go through the clients and check the match
- processCGI: it is very similar to processClient, same concept only that the fd needs only to be on read. I believe we can have only one, but I haven't manage to do so yet
- after sending the output of the script to the client, we close the fd where the server read from and also the client, we remove them from poll and client list. I was not able to make it work without removing it from the poll sets both right away
- add signal to catch when terminating the program and freeing all the allocated memory, close fds and processes

Also couple changes in the scripts:
upload.py: remove the class FieldStorage and passing as env the name of the script. Since all it is parsed, I think we don't need to call this class and it was not working (for me at least), I kept getting the error "field name not found in form".
loop.py: remove the print statement

What we are missing

- implement custom error page
- page for 504 gateway for when the timeout happens, we are not sending any message to the client that the server closed connection

My test is siege with no time and try to do any other action: static uploads, dynamic uploads, retrieve pages and delete 

