### PR TITLE
Custom error page

### DIFF
--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -59,6 +59,7 @@ class ClientHandler {
 		int 		createResponse(void);
 		int			retrieveResponse(void);
 		int 		isCgi(std::string str);
+		std::string createBodyError(int code, std::string str);
 
 	private:
 	int 		client_fd;

--- a/default.conf
+++ b/default.conf
@@ -58,49 +58,50 @@ server {
 	}
 
 	# Route to serve the error files (these files should exist at the specified locations)
-	location /400 {
-		internal;
-	}
-
-	location /403 {
-		internal;
-	}
-
 	location /404 {
+		return			custom_404.html;
 		internal;
 	}
 
-	location /405 {
-		internal;
-	}
+	# location /403 {
+	# 	internal;
+	# }
 
-	location /409 {
-		internal;
-	}
+	# # location /404 {
+	# # 	internal;
+	# # }
 
-	location /413 {
-		internal;
-	}
+	# location /405 {
+	# 	internal;
+	# }
 
-	location /415 {
-		internal;
-	}
+	# location /409 {
+	# 	internal;
+	# }
 
-	location /501 {
-		internal;
-	}
+	# location /413 {
+	# 	internal;
+	# }
 
-	location /502 {
-		internal;
-	}
+	# location /415 {
+	# 	internal;
+	# }
 
-	location /504 {
-		internal;
-	}
+	# location /501 {
+	# 	internal;
+	# }
 
-	location /505 {
-		internal;
-	}
+	# location /502 {
+	# 	internal;
+	# }
+
+	# location /504 {
+	# 	internal;
+	# }
+
+	# location /505 {
+	# 	internal;
+	# }
 }
 
 server {

--- a/www/errors/custom_404.html
+++ b/www/errors/custom_404.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Webserv - 404 Red Chaos</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Courier New', monospace;
+            background: #1db2a8;
+            color: #ffcc00;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            position: relative;
+            overflow: hidden;
+        }
+        .error {
+            transform: skew(-10deg);
+            padding: 50px;
+            border: 4px solid #ff6600;
+            animation: glitch 0.5s infinite;
+            text-align: center;
+        }
+        h1 {
+            font-size: 80px;
+            margin: 0;
+            text-shadow: 0 0 20px #ff3300;
+            animation: flicker 0.1s infinite;
+        }
+        p {
+            font-size: 24px;
+            margin: 15px 0;
+        }
+        a {
+            color: #ff6600;
+            text-decoration: none;
+            font-weight: bold;
+            padding: 10px;
+            border: 2px solid #ff6600;
+            transition: all 0.3s;
+        }
+        a:hover {
+            background: #ff6600;
+            color: #cc0000;
+            transform: rotate(10deg);
+            box-shadow: 0 0 20px #ff6600;
+        }
+        .bg-anim {
+            position: absolute;
+            width: 120px;
+            height: 120px;
+            background: rgba(255, 51, 0, 0.6);
+            border-radius: 50%;
+            animation: float 6s infinite ease-in-out;
+        }
+        .bg-anim:nth-child(1) { top: 30%; left: 25%; animation-delay: 0s; }
+        .bg-anim:nth-child(2) { bottom: 20%; right: 30%; animation-delay: 2s; }
+        @keyframes glitch {
+            0% { transform: skew(-10deg) translate(0, 0); }
+            50% { transform: skew(10deg) translate(5px, -5px); }
+            100% { transform: skew(-10deg) translate(0, 0); }
+        }
+        @keyframes flicker {
+            0% { opacity: 1; }
+            50% { opacity: 0.8; }
+            100% { opacity: 1; }
+        }
+        @keyframes float {
+            0% { transform: translate(0, 0); }
+            50% { transform: translate(40px, -40px); }
+            100% { transform: translate(0, 0); }
+        }
+    </style>
+</head>
+<body>
+    <div class="bg-anim"></div>
+    <div class="bg-anim"></div>
+    <div class="error">
+        <h1>404</h1>
+        <p>Page Lost in the Red Void!</p>
+        <a href="/">Escape the Chaos</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Add logic to use a custom error page if a location block is present, I added createBodyError function check if there is location block of the error: if yes we retrieve the file and serve the custom page; if not, we give the default one.
So we only need to write blocks for custom pages. Right now the block is the error and return refers to the name of the error page. The path is provided already by parsing, they will always be in /www/errors/custom_404.html. It can be changed, I didn't know better.
```
location /404 {
		return			custom_404.html;
		internal;
	}
```