### PR TITLE
Linux tests

### DIFF
--- a/CGI.cpp
+++ b/CGI.cpp
@@ -117,7 +117,7 @@ void CGI::createAv()
 	if (extension.find(".py") != std::string::npos)
 		_av[0] = strdup("/usr/bin/python3");
 	else if (extension.find(".php") != std::string::npos)
-		_av[0] = strdup("/opt/homebrew/bin/php"); ///usr/bin/php-cgi or /opt/homebrew/bin/php
+		_av[0] = strdup("/usr/bin/php-cgi"); ///usr/bin/php-cgi or /opt/homebrew/bin/php
 	else
 		throw InternalServerErrorException();
 	//Argument 1 is the script

--- a/CGI.cpp
+++ b/CGI.cpp
@@ -22,8 +22,8 @@ CGI::CGI(const HttpRequest& request, const std::string& upload_dir, const std::s
 	// _timeout(serverInfo.getCGIProcessingTimeout()),
 	_serverInfo(serverInfo)
 {
-	try
-	{
+	// try
+	// {
 		// Logger::debug("Initializing CGI for Server " + _serverInfo.getIP() + ":" + _serverInfo.getPort());
 		// std::string content_type = request.getHttpHeaders().count("content-type") ? request.getHttpHeaders().find("content-type")->second : "";
 		// Logger::debug("Content-Type: " + content_type);
@@ -39,12 +39,12 @@ CGI::CGI(const HttpRequest& request, const std::string& upload_dir, const std::s
 		createAv();
 		createEnv(request);
 		startExecution();
-	}
-	catch (const std::exception& e)
-	{
-		// closePipes();
-		// throw CGIException("CGI init failed: " + std::string(e.what()));
-	}
+	// }
+	// catch (const std::exception& e)
+	// {
+	// 	// closePipes();
+	// 	// throw CGIException("CGI init failed: " + std::string(e.what()));
+	// }
 }
 
 CGI::~CGI()
@@ -112,7 +112,7 @@ void CGI::createAv()
 	// Extract the file extension from cgi_path
 	//Argument zero is where to find the command to run the script
 	std::string extension = _cgi_path.substr(_cgi_path.find_last_of("."));
-	if (_serverInfo.getCGI().locSettings["cgi_extension"].find(extension) == std::string::npos)
+	if (_serverInfo.getCGI().locSettings["cgi_extension"].find(extension) == std::string::npos && _serverInfo.getCGI().locSettings["cgi_extension"].find(extension) != 0)
 		throw UnsupportedMediaTypeException();
 	if (extension.find(".py") != std::string::npos)
 		_av[0] = strdup("/usr/bin/python3");
@@ -233,6 +233,7 @@ void CGI::startExecution()
 	Logger::debug("Checking env");
 	for (int i = 0; _env[i]; i++)
 		Logger::debug(std::string(_env[i]));
+	Logger::debug("get pid: " + Utils::toString(getpid()));
 	if (_pid == 0 ) //child
 	{
 		signal(SIGPIPE, SIG_IGN);// Mark SIGPIPE to prevent crashes

--- a/CGI.hpp
+++ b/CGI.hpp
@@ -3,6 +3,7 @@
 
 #include "HttpRequest.hpp"
 #include "ClientHandler.hpp"
+#include "HttpException.hpp"
 #include "Config.hpp"
 #include "Logger.hpp"
 #include <iostream>
@@ -19,6 +20,13 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <fstream>
+
+class CGIException : public std::runtime_error {
+
+    public:
+        explicit CGIException(const std::string& message) : std::runtime_error(message) {}
+
+};
 
 class CGI {
 

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -275,7 +275,7 @@ int ClientHandler::retrieveResponse(void)
 	this->totbytes = 0;
 	this->request.cleanProperties();
 	this->startingTime = time(NULL);
-	return this->internal_fd;
+	return bytes;
 }
 
 std::string ClientHandler::retrievePage(struct Route route)

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -392,12 +392,19 @@ int ClientHandler::readStdout(int fd)
 {
 	int res = 0;
 	char buffer[BUFFER];
-	Utils::ft_memset(buffer, 0, sizeof(buffer));
-	res = read(fd, buffer, BUFFER - 1);
-	this->raw_data.append(buffer, res);
-	if (res > 0)
-		return 0;
-	else if (res == -1 && this->totbytes == 0)
+	///if don't read all from the pipe right away it goes to POLLHUP
+	while (1)
+	{
+		Utils::ft_memset(buffer, 0, sizeof(buffer));
+		res = read(fd, buffer, BUFFER - 1);
+		if (res == 0)
+			break;
+		this->raw_data.append(buffer, res);
+	}
+	Logger::debug("bytes read: " + Utils::toString(this->raw_data.size()));
+	// if (res > 0)
+	// 	return 0;
+	if (res == -1 && this->totbytes == 0)
 		return 1;
 	return 2;
 }

--- a/ClientHandler.cpp
+++ b/ClientHandler.cpp
@@ -254,7 +254,6 @@ int ClientHandler::readData(int fd, std::string &str, int &bytes)
 	char buffer[BUFFER];
 
 	Utils::ft_memset(buffer, 0, sizeof(buffer));
-	Logger::error("buffer error memset");
 	res = recv(fd, buffer, BUFFER, MSG_DONTWAIT);
 	if (res > 0)
 		str.append(buffer, res);

--- a/ClientHandler.hpp
+++ b/ClientHandler.hpp
@@ -59,6 +59,7 @@ class ClientHandler {
 		int 		createResponse(void);
 		int			retrieveResponse(void);
 		int 		isCgi(std::string str);
+		std::string createBodyError(int code, std::string str);
 
 	private:
 	int 		client_fd;

--- a/ServerSockets.cpp
+++ b/ServerSockets.cpp
@@ -59,7 +59,7 @@ int ServerSockets::createSocket(void)
 	error = getaddrinfo(this->ip.c_str(), this->port.c_str(), &hints, &serverInfo);
 	if (error < 0)
 		Logger::error("Failed getaddrinfo: " + std::string(gai_strerror(errno)));
-	fd = socket(serverInfo->ai_family, hints.ai_socktype, 0);
+	fd = socket(serverInfo->ai_family, hints.ai_socktype | SOCK_NONBLOCK, 0);
 	if (fd == -1)
 	{
 		Logger::error("Failed socket: " + std::string(strerror(errno)));

--- a/ServerSockets.cpp
+++ b/ServerSockets.cpp
@@ -59,7 +59,7 @@ int ServerSockets::createSocket(void)
 	error = getaddrinfo(this->ip.c_str(), this->port.c_str(), &hints, &serverInfo);
 	if (error < 0)
 		Logger::error("Failed getaddrinfo: " + std::string(gai_strerror(errno)));
-	fd = socket(serverInfo->ai_family, hints.ai_socktype | SOCK_NONBLOCK, 0);
+	fd = socket(serverInfo->ai_family, hints.ai_socktype, 0);
 	if (fd == -1)
 	{
 		Logger::error("Failed socket: " + std::string(strerror(errno)));

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -230,8 +230,8 @@ int Webserver::processCGI(int fd)
 		return 0;
 	}
 	status = clientIt->readStdout(fd);
-	if (status == DONE)
-		status = clientIt->createResponse();
+	// if (status == DONE)
+	clientIt->createResponse();
 	return status;
 }
 

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -100,11 +100,13 @@ void Webserver::dispatchEvents()
 				result = processClient(it->fd, READ);
 				if (result == DISCONNECTED)
 				{
-					Logger::debug("event on it->fd: " + Utils::toString(it->fd));
-					std::vector<ClientHandler>::iterator clientIt = retrieveClientCGI(it->fd);
+					std::vector<ClientHandler>::iterator clientIt = retrieveClient(it->fd);
+					Logger::info("fd cgi: " + Utils::toString(clientIt->getCGI_Fd()));
 					if (clientIt->getCGI_Fd() > 0)
 					{
-						close(clientIt->getCGI_Fd());
+						Logger::info("pid process when disconnecting client: " + Utils::toString(clientIt->getPid()));
+						if (clientIt->getPid() > 1)
+							kill(clientIt->getPid(), SIGTERM);
 						for (int i = 0; i < poll_sets.size(); i++)
 						{
 							if (poll_sets[i].fd == clientIt->getCGI_Fd()) {
@@ -124,7 +126,7 @@ void Webserver::dispatchEvents()
 					std::vector<ClientHandler>::iterator clientIt = retrieveClient(it->fd);
 					if (clientIt->getCGI_Fd() > 0)
 					{
-						std::cout << "before add to poll: " << clientIt->getCGI_Fd() << std::endl;
+						std::cout << "add to the poll: " << clientIt->getCGI_Fd() << std::endl;
 						struct pollfd CGIPoll;
 
 						CGIPoll.fd = retrieveClient(it->fd)->getCGI_Fd();

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -184,7 +184,7 @@ void Webserver::dispatchEvents()
 		{
 			Logger::debug("POLLINVAL");
 			Logger::error("Fd " + Utils::toString(it->fd) + ": invalid request, fd not open");
-			poll_sets.erase(it);
+			removeClient(it);
 			return;
 		}
 		else

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -57,9 +57,7 @@ int	Webserver::startServer()
 			Logger::debug("Poll timeout: no events");
 		else
 			dispatchEvents();
-		std::cout << "exit dispatch\n";
 		checkTime();
-		std::cout << "after timecheck\n";
 	}
 	return 0;
 }
@@ -101,10 +99,8 @@ void Webserver::dispatchEvents()
 				if (result == DISCONNECTED)
 				{
 					std::vector<ClientHandler>::iterator clientIt = retrieveClient(it->fd);
-					Logger::info("fd cgi: " + Utils::toString(clientIt->getCGI_Fd()));
 					if (clientIt->getCGI_Fd() > 0)
 					{
-						Logger::info("pid process when disconnecting client: " + Utils::toString(clientIt->getPid()));
 						if (clientIt->getPid() > 1)
 							kill(clientIt->getPid(), SIGTERM);
 						for (int i = 0; i < poll_sets.size(); i++)
@@ -126,7 +122,6 @@ void Webserver::dispatchEvents()
 					std::vector<ClientHandler>::iterator clientIt = retrieveClient(it->fd);
 					if (clientIt->getCGI_Fd() > 0)
 					{
-						std::cout << "add to the poll: " << clientIt->getCGI_Fd() << std::endl;
 						struct pollfd CGIPoll;
 
 						CGIPoll.fd = retrieveClient(it->fd)->getCGI_Fd();
@@ -210,13 +205,9 @@ int Webserver::processClient(int fd, int event)
 		return 0;
 	}
 	if (event == READ)
-	{
 		status = clientIt->manageRequest();
-	}
 	else
-	{
 		status = clientIt->retrieveResponse();
-	}
 	return status;
 }
 
@@ -232,7 +223,6 @@ int Webserver::processCGI(int fd)
 		return 0;
 	}
 	status = clientIt->readStdout(fd);
-	// if (status == DONE)
 	clientIt->createResponse();
 	return status;
 }
@@ -354,7 +344,6 @@ void Webserver::closeSockets()
 void Webserver::removeClient(std::vector<struct pollfd>::iterator it)
 {
 	Logger::info("Client " + Utils::toString(it->fd) + " disconnected");
-	Logger::debug("even on it->fd: " + Utils::toString(it->fd));
 	close(it->fd);
 	if (retrieveClient(it->fd) != this->clientsList.end())
 		this->clientsList.erase(retrieveClient(it->fd));
@@ -373,10 +362,8 @@ void Webserver::checkTime(void)
 		{
 			if (currentTime - clientIt->getTime() > clientIt->getTimeOut())
 			{
-				Logger::error("Fd: " + Utils::toString(it->fd) + " timeout");
 				if (clientIt->getCGI_Fd() > 0)
 				{
-					std::cout << "script\n";
 					for (int i = 0; i < poll_sets.size(); i++)
 					{
 						Logger::warn(Utils::toString(poll_sets[i].fd));
@@ -394,7 +381,6 @@ void Webserver::checkTime(void)
 					it->events = POLLOUT;
 					return;
 				}
-				std::cout << "in check timeout\n";
 				removeClient(it);
 				break;
 			}

--- a/WebServer.cpp
+++ b/WebServer.cpp
@@ -121,9 +121,10 @@ void Webserver::dispatchEvents()
 					it->events = POLLOUT;
 				else if (result == 3)
 				{
-					std::vector<ClientHandler>::iterator clientIt = retrieveClientCGI(it->fd);
+					std::vector<ClientHandler>::iterator clientIt = retrieveClient(it->fd);
 					if (clientIt->getCGI_Fd() > 0)
 					{
+						std::cout << "before add to poll: " << clientIt->getCGI_Fd() << std::endl;
 						struct pollfd CGIPoll;
 
 						CGIPoll.fd = retrieveClient(it->fd)->getCGI_Fd();

--- a/default.conf
+++ b/default.conf
@@ -58,49 +58,50 @@ server {
 	}
 
 	# Route to serve the error files (these files should exist at the specified locations)
-	location /400 {
-		internal;
-	}
-
-	location /403 {
-		internal;
-	}
-
 	location /404 {
+		return			custom_404.html;
 		internal;
 	}
 
-	location /405 {
-		internal;
-	}
+	# location /403 {
+	# 	internal;
+	# }
 
-	location /409 {
-		internal;
-	}
+	# # location /404 {
+	# # 	internal;
+	# # }
 
-	location /413 {
-		internal;
-	}
+	# location /405 {
+	# 	internal;
+	# }
 
-	location /415 {
-		internal;
-	}
+	# location /409 {
+	# 	internal;
+	# }
 
-	location /501 {
-		internal;
-	}
+	# location /413 {
+	# 	internal;
+	# }
 
-	location /502 {
-		internal;
-	}
+	# location /415 {
+	# 	internal;
+	# }
 
-	location /504 {
-		internal;
-	}
+	# location /501 {
+	# 	internal;
+	# }
 
-	location /505 {
-		internal;
-	}
+	# location /502 {
+	# 	internal;
+	# }
+
+	# location /504 {
+	# 	internal;
+	# }
+
+	# location /505 {
+	# 	internal;
+	# }
 }
 
 server {

--- a/default.conf
+++ b/default.conf
@@ -4,7 +4,7 @@ server {
 	root					/www;
 	error_path				/www/errors;
 	client_max_body_size	1000000;
-	keepalive_timeout		75;
+	keepalive_timeout		10;
 	cgi_processing_timeout	15;
 
 	# specifies how the server should respond to requests for the root path (no path specified)

--- a/default.conf
+++ b/default.conf
@@ -3,8 +3,8 @@ server {
 	server_name				localhost;
 	root					/www;
 	error_path				/www/errors;
-	client_max_body_size	1;
-	keepalive_timeout		10;
+	client_max_body_size	1000000;
+	keepalive_timeout		75;
 	cgi_processing_timeout	15;
 
 	# specifies how the server should respond to requests for the root path (no path specified)

--- a/main.cpp
+++ b/main.cpp
@@ -122,6 +122,7 @@ int main(void)
 
 	signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
+	signal(SIGPIPE, SIG_IGN);
 
 	if (configuration->ft_validServer())
 	{

--- a/www/cgi-bin/loop.py
+++ b/www/cgi-bin/loop.py
@@ -8,7 +8,15 @@ print("Content-Type: text/plain")
 print()  # Blank line to end headers
 
 # Infinite loop
-while True:
-    # print("This is an infinite loop")
-    # sys.stdout.flush()  # Ensure output is sent immediately
-    time.sleep(1)  # Slow it down to simulate processing
+try:
+    while True:
+        time.sleep(1)  # Slow it down to simulate processing
+        print("Processing...")
+except KeyboardInterrupt:
+    print("Process interrupted. Exiting...")
+except BrokenPipeError:
+    # Handle the broken pipe error if necessary
+    pass
+finally:
+        # Any cleanup code can go here
+        print("Cleanup complete.")

--- a/www/cgi-bin/loop.py
+++ b/www/cgi-bin/loop.py
@@ -7,13 +7,13 @@ print("Content-Type: text/plain")
 print()  # Blank line to end headers
 
 # Infinite loop
-try:
-    while True:
-        time.sleep(1)
-except KeyboardInterrupt:
-    print("Process interrupted. Exiting...")
-except (BrokenPipeError, IOError):
-    print ('BrokenPipeError caught', file = sys.stderr)
+# try:
+while True:
+    time.sleep(1)
+# except KeyboardInterrupt:
+#     print("Process interrupted. Exiting...")
+# except (BrokenPipeError, IOError):
+#     print ('BrokenPipeError caught', file = sys.stderr)
 
-print ('Done', file=sys.stderr)
-sys.stderr.close()
+# `print ('Done', file=sys.stderr)
+# sys.stderr.close()`

--- a/www/cgi-bin/loop.py
+++ b/www/cgi-bin/loop.py
@@ -3,20 +3,17 @@
 import sys
 import time
 
-# CGI requires headers first
 print("Content-Type: text/plain")
 print()  # Blank line to end headers
 
 # Infinite loop
 try:
     while True:
-        time.sleep(1)  # Slow it down to simulate processing
-        print("Processing...")
+        time.sleep(1)
 except KeyboardInterrupt:
     print("Process interrupted. Exiting...")
-except BrokenPipeError:
-    # Handle the broken pipe error if necessary
-    pass
-finally:
-        # Any cleanup code can go here
-        print("Cleanup complete.")
+except (BrokenPipeError, IOError):
+    print ('BrokenPipeError caught', file = sys.stderr)
+
+print ('Done', file=sys.stderr)
+sys.stderr.close()

--- a/www/cgi-bin/loop.py
+++ b/www/cgi-bin/loop.py
@@ -15,5 +15,5 @@ while True:
 # except (BrokenPipeError, IOError):
 #     print ('BrokenPipeError caught', file = sys.stderr)
 
-# `print ('Done', file=sys.stderr)
+# print ('Done', file=sys.stderr)
 # sys.stderr.close()`

--- a/www/errors/custom_404.html
+++ b/www/errors/custom_404.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Webserv - 404 Red Chaos</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Courier New', monospace;
+            background: #1db2a8;
+            color: #ffcc00;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            position: relative;
+            overflow: hidden;
+        }
+        .error {
+            transform: skew(-10deg);
+            padding: 50px;
+            border: 4px solid #ff6600;
+            animation: glitch 0.5s infinite;
+            text-align: center;
+        }
+        h1 {
+            font-size: 80px;
+            margin: 0;
+            text-shadow: 0 0 20px #ff3300;
+            animation: flicker 0.1s infinite;
+        }
+        p {
+            font-size: 24px;
+            margin: 15px 0;
+        }
+        a {
+            color: #ff6600;
+            text-decoration: none;
+            font-weight: bold;
+            padding: 10px;
+            border: 2px solid #ff6600;
+            transition: all 0.3s;
+        }
+        a:hover {
+            background: #ff6600;
+            color: #cc0000;
+            transform: rotate(10deg);
+            box-shadow: 0 0 20px #ff6600;
+        }
+        .bg-anim {
+            position: absolute;
+            width: 120px;
+            height: 120px;
+            background: rgba(255, 51, 0, 0.6);
+            border-radius: 50%;
+            animation: float 6s infinite ease-in-out;
+        }
+        .bg-anim:nth-child(1) { top: 30%; left: 25%; animation-delay: 0s; }
+        .bg-anim:nth-child(2) { bottom: 20%; right: 30%; animation-delay: 2s; }
+        @keyframes glitch {
+            0% { transform: skew(-10deg) translate(0, 0); }
+            50% { transform: skew(10deg) translate(5px, -5px); }
+            100% { transform: skew(-10deg) translate(0, 0); }
+        }
+        @keyframes flicker {
+            0% { opacity: 1; }
+            50% { opacity: 0.8; }
+            100% { opacity: 1; }
+        }
+        @keyframes float {
+            0% { transform: translate(0, 0); }
+            50% { transform: translate(40px, -40px); }
+            100% { transform: translate(0, 0); }
+        }
+    </style>
+</head>
+<body>
+    <div class="bg-anim"></div>
+    <div class="bg-anim"></div>
+    <div class="error">
+        <h1>404</h1>
+        <p>Page Lost in the Red Void!</p>
+        <a href="/">Escape the Chaos</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
I started to test on Linux (something I should have done before), and these are the current fixes:

1. Webserver class
dispatchEvents line 101
`std::vector<ClientHandler>::iterator clientIt = retrieveClient(it->fd);` before I was retrieve wrong iterator from the retrieveCGIClient - I was never able to stop the script "gracefully" and I would get a Broken pipe since the script was trying to write on a close fd
2. ClientHandler
readStdout
```
int res = 0;
	char buffer[BUFFER];
	///if don't read all from the pipe right away it goes to POLLHUP
	while (1)
	{
		Utils::ft_memset(buffer, 0, sizeof(buffer));
		res = read(fd, buffer, BUFFER - 1);
		if (res == 0)
			break;
		this->raw_data.append(buffer, res);
	}
	if (res == -1 && this->totbytes == 0)
		return 1;
	return 2;
```
Reading from the stdout in a loop till we reach read 0 (no more bytes to read). If not, I was getting POLLHUP. I experienced this only on Linux
3. Loop.py: no more writing on the screen; I don't get how this part works very well and I dont want to mess it up
